### PR TITLE
Replace linked-list allocator with TLSF

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,31 @@ name = "alloc-cortex-m"
 version = "0.4.0"
 
 [dependencies]
+tlsf = { git = "https://github.com/FluenTech/tlsf" }
 cortex-m = "0.6.2"
 
-[dependencies.linked_list_allocator]
-default-features = false
-version = "0.8.1"
+[features]
+FLI6 = ["tlsf/FLI6"]
+FLI7 = ["tlsf/FLI7"]
+FLI8 = ["tlsf/FLI8"]
+FLI9 = ["tlsf/FLI9"]
+FLI10 = ["tlsf/FLI10"]
+FLI11 = ["tlsf/FLI11"]
+FLI12 = ["tlsf/FLI12"]
+FLI13 = ["tlsf/FLI13"]
+FLI14 = ["tlsf/FLI14"]
+FLI15 = ["tlsf/FLI15"]
+
+#[dependencies.linked_list_allocator]
+#default-features = false
+#version = "0.8.1"
+
 
 [dev-dependencies]
+nrf52832-hal = { version = "0.10.0", default-features = false, features = ["rt", "xxAA-package"] }
+cortex-m = "0.6.2"
+panic-halt = "0.2.0"
+spin = "0.5.2"
+jlink_rtt = "0.2.0"
+panic_rtt = "0.3.0"
 cortex-m-rt = "0.6.12"

--- a/examples/.cargo/config
+++ b/examples/.cargo/config
@@ -1,0 +1,14 @@
+[target.'cfg(all(target_arch = "arm", target_os = "none"))']
+rustflags = [
+  # LLD (shipped with the Rust toolchain) is used as the default linker
+  "-C", "link-arg=-Tlink.x",
+]
+
+[build]
+target = "thumbv7em-none-eabihf" # Cortex-M4F and Cortex-M7F (with FPU)
+
+[profile.release]
+codegen-units = 1 # better optimizations
+debug = true # symbols are nice and they don't increase the size on Flash
+lto = true # better optimizations
+opt-level = "z"

--- a/examples/global_alloc.rs
+++ b/examples/global_alloc.rs
@@ -22,10 +22,7 @@ fn main() -> ! {
     static mut M: Aligned<[u8; tlsf::MAX_BLOCK_SIZE as usize]> =
         Aligned([0; tlsf::MAX_BLOCK_SIZE as usize]);
 
-    // Initialize the allocator BEFORE you use it
-    // let start = cortex_m_rt::heap_start() as usize;
-    // let size = 1024; // in bytes
-    unsafe { ALLOCATOR.extend(&mut M.0) }
+    ALLOCATOR.extend(&mut M.0);
 
     let mut xs = Vec::new();
     xs.push(1);

--- a/examples/nrf52_dk.rs
+++ b/examples/nrf52_dk.rs
@@ -4,8 +4,8 @@
 #![feature(alloc_error_handler)]
 
 extern crate alloc;
-extern crate panic_rtt;
 extern crate nrf52832_hal;
+extern crate panic_rtt;
 
 use alloc::vec::Vec;
 use alloc_cortex_m::CortexMHeap;
@@ -26,18 +26,16 @@ fn main() -> ! {
         Aligned([0; tlsf::MAX_BLOCK_SIZE as usize]);
 
     let mut log = NonBlockingOutput::new();
-    writeln!(log, "Output stream opened");
-    // Initialize the allocator BEFORE you use it
-    // let start = cortex_m_rt::heap_start() as usize;
-    // let size = 1024; // in bytes
-    unsafe { ALLOCATOR.extend(&mut M.0) }
+    writeln!(log, "Output stream opened").ok().unwrap();
 
-    writeln!(log, "Heap extended");
+    ALLOCATOR.extend(&mut M.0);
+
+    writeln!(log, "Heap extended").ok().unwrap();
 
     let mut xs = Vec::new();
     xs.push(1);
 
-    writeln!(log, "Vector instantiated");
+    writeln!(log, "Vector instantiated").ok().unwrap();
 
     loop {
         xs.push(1);

--- a/examples/nrf52_dk.rs
+++ b/examples/nrf52_dk.rs
@@ -1,15 +1,18 @@
-#![no_std]
 #![no_main]
+#![no_std]
+#![feature(alloc_prelude)]
 #![feature(alloc_error_handler)]
 
 extern crate alloc;
+extern crate panic_rtt;
+extern crate nrf52832_hal;
 
 use alloc::vec::Vec;
 use alloc_cortex_m::CortexMHeap;
 use core::alloc::Layout;
 use core::fmt::Write;
-use core::panic::PanicInfo;
 use cortex_m_rt::entry;
+use jlink_rtt::NonBlockingOutput;
 
 #[global_allocator]
 static ALLOCATOR: CortexMHeap = CortexMHeap::empty();
@@ -22,23 +25,26 @@ fn main() -> ! {
     static mut M: Aligned<[u8; tlsf::MAX_BLOCK_SIZE as usize]> =
         Aligned([0; tlsf::MAX_BLOCK_SIZE as usize]);
 
+    let mut log = NonBlockingOutput::new();
+    writeln!(log, "Output stream opened");
     // Initialize the allocator BEFORE you use it
     // let start = cortex_m_rt::heap_start() as usize;
     // let size = 1024; // in bytes
     unsafe { ALLOCATOR.extend(&mut M.0) }
 
+    writeln!(log, "Heap extended");
+
     let mut xs = Vec::new();
     xs.push(1);
 
-    loop { /* .. */ }
+    writeln!(log, "Vector instantiated");
+
+    loop {
+        xs.push(1);
+    }
 }
 
 #[alloc_error_handler]
 fn oom(_: Layout) -> ! {
-    loop {}
-}
-
-#[panic_handler]
-fn panic(_: &PanicInfo) -> ! {
-    loop {}
+    panic!("alloc error");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,29 @@
 //! # Example
 //!
 //! For a usage example, see `examples/global_alloc.rs`.
+//!
+//! # Features
+//!
+//! The First Level Index (FLI) must be specified. The FLI determines the tlsf overhead required,
+//! the largest object that can be stored on the heap, and the largest block that can be used to
+//! _extend_ the memory pool.
+//!
+//! The FLI can be specified by setting one of the FLIx features in the range of FLI6..=FLI15.
+//!
+//! |FLI|`size_of(Tlsf)`|`MAX_REQUEST_SIZE`|`MAX_BLOCK_SIZE`|
+//! |---|---------------|------------------|----------------|
+//! |6  |36             |60                |60              |
+//! |7  |70             |120               |124             |
+//! |8  |104            |240               |252             |
+//! |9  |138            |480               |508             |
+//! |10 |172            |960               |1,020           |
+//! |11 |206            |1,920             |2,044           |
+//! |12 |240            |3,840             |4,092           |
+//! |13 |274            |7,680             |8,188           |
+//! |14 |308            |15,360            |16,380          |
+//! |15 |342            |30,720            |32,764          |
+//!
+//! *All sizes are in bytes*
 
 #![no_std]
 
@@ -13,7 +36,6 @@ use core::cell::RefCell;
 use core::ptr::NonNull;
 
 use cortex_m::interrupt::Mutex;
-// use linked_list_allocator::Heap;
 use tlsf::Tlsf as Heap;
 
 pub struct CortexMHeap {
@@ -21,45 +43,36 @@ pub struct CortexMHeap {
 }
 
 impl CortexMHeap {
-    /// Crate a new UNINITIALIZED heap allocator
+    /// Create a new heap allocator, with an empty memory pool
     ///
-    /// You must initialize this heap using the
-    /// [`init`](struct.CortexMHeap.html#method.init) method before using the allocator.
+    /// The allocator's memory pool must be extended using the
+    /// [`extend`](struct.CortexMHeap.html#method.extend) method before using the allocator.
     pub const fn empty() -> CortexMHeap {
         CortexMHeap {
             heap: Mutex::new(RefCell::new(Heap::new())),
         }
     }
 
-    /// Initializes the heap
+    /// Adds a memory _chunk_ to the allocator's memory pool
     ///
-    /// This function must be called BEFORE you run any code that makes use of the
+    /// This function must be called at least once BEFORE any code makes use of the
     /// allocator.
     ///
-    /// `start_addr` is the address where the heap will be located.
+    /// # Examples
     ///
-    /// `size` is the size of the heap in bytes.
+    /// ```rust
+    /// use alloc_cortex_m::CortexMHeap;
     ///
-    /// Note that:
+    /// static ALLOCATOR: CortexMHeap = CortexMHeap::empty();
     ///
-    /// - The heap grows "upwards", towards larger addresses. Thus `end_addr` must
-    ///   be larger than `start_addr`
+    /// static mut CHUNK: [u8; tlsf::MAX_BLOCK_SIZE as usize] =
+    ///         [0; tlsf::MAX_BLOCK_SIZE as usize];
     ///
-    /// - The size of the heap is `(end_addr as usize) - (start_addr as usize)`. The
-    ///   allocator won't use the byte at `end_addr`.
-    ///
-    /// # Unsafety
-    ///
-    /// Obey these or Bad Stuff will happen.
-    ///
-    /// - This function must be called exactly ONCE.
-    /// - `size > 0`
-    pub unsafe fn extend(&self, block: &'static mut [u8]) {
+    /// unsafe { ALLOCATOR.extend(&mut CHUNK) }
+    /// ```
+    pub fn extend(&self, block: &'static mut [u8]) {
         cortex_m::interrupt::free(move |cs| {
-            self.heap
-                .borrow(cs)
-                .borrow_mut()
-                .extend(block);
+            self.heap.borrow(cs).borrow_mut().extend(block);
         });
     }
 }


### PR DESCRIPTION
This appears to be working with the nrf52_dk example I added. I would like to add a bit more instrumentation to it and look into what changes might make sense on TLSF.

Fixes #36 