### PR TITLE
Remove alloc_error_handler

### DIFF
--- a/examples/global_alloc.rs
+++ b/examples/global_alloc.rs
@@ -1,11 +1,9 @@
 #![no_std]
 #![no_main]
-#![feature(alloc_error_handler)]
 
 extern crate alloc;
 
 use alloc::vec::Vec;
-use core::alloc::Layout;
 use core::panic::PanicInfo;
 use cortex_m_rt::entry;
 use embedded_alloc::Heap;
@@ -27,11 +25,6 @@ fn main() -> ! {
     xs.push(1);
 
     loop { /* .. */ }
-}
-
-#[alloc_error_handler]
-fn oom(_: Layout) -> ! {
-    loop {}
 }
 
 #[panic_handler]


### PR DESCRIPTION
With https://github.com/rust-lang/rust/pull/102318, default_alloc_error_handler has been stabilized, ie. the default error handler is enabled by default.

Therefore, it's no longer necessary to provide an alloc_error_handler if the desired error handling is equivalent to a panic.