### PR TITLE
Remove legacy const_mut_refs feature on linked_list_allocator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ critical-section = "1.0"
 [dependencies.linked_list_allocator]
 default-features = false
 version = "0.10.5"
-features = ["const_mut_refs"]
 
 [dev-dependencies]
 cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }


### PR DESCRIPTION
This feature has been marked obsolete, see: https://github.com/rust-osdev/linked-list-allocator/blob/9645f4262ba1b9efa3336b59a82541662d2340cb/Cargo.toml#L22