### PR TITLE
edition: 2018 -> 2021

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - The `Heap` struct has been renamed to `LlffHeap` and requires the `llff` feature.
+- Updated the rust edition from 2018 to 2021.
 
 ## [v0.5.1] - 2023-11-04
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ description = "A heap allocator for embedded systems"
 repository = "https://github.com/rust-embedded/embedded-alloc"
 documentation = "https://docs.rs/embedded-alloc"
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 
 keywords = [
     "allocator",


### PR DESCRIPTION
The MSRV is set at 1.68 so this shouldn't be breaking.