### PR TITLE
Add TLSF memory usage API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Added a `init` macro to make initialization easier.
+- Added `Heap::free` and `Heap::used` for the TLSF heap.
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ llff = ["linked_list_allocator"]
 [dependencies]
 critical-section = "1.0"
 linked_list_allocator = { version = "0.10.5", default-features = false, optional = true }
-rlsf = { version = "0.2.1", default-features = false, optional = true }
+rlsf = { version = "0.2.1", default-features = false, features = ["unstable"], optional = true }
 const-default = { version = "1.0.0", default-features = false, optional = true }
 
 [dev-dependencies]

--- a/examples/allocator_api.rs
+++ b/examples/allocator_api.rs
@@ -34,5 +34,5 @@ fn main() -> ! {
 #[panic_handler]
 fn panic(info: &PanicInfo) -> ! {
     defmt::error!("{}", info);
-    semihosting::process::exit(0);
+    semihosting::process::exit(-1);
 }

--- a/examples/exhaustion.rs
+++ b/examples/exhaustion.rs
@@ -1,0 +1,38 @@
+//! Example which shows behavior on pool exhaustion. It simply panics.
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use cortex_m as _;
+use cortex_m_rt::entry;
+use defmt::Debug2Format;
+use defmt_semihosting as _;
+
+use core::panic::PanicInfo;
+use embedded_alloc::TlsfHeap as Heap;
+
+#[global_allocator]
+static HEAP: Heap = Heap::empty();
+
+#[entry]
+fn main() -> ! {
+    // Initialize the allocator BEFORE you use it
+    unsafe {
+        embedded_alloc::init!(HEAP, 16);
+    }
+
+    let _vec = alloc::vec![0; 16];
+
+    defmt::error!("unexpected vector allocation success");
+
+    // Panic is expected here.
+    semihosting::process::exit(-1);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    defmt::warn!("received expected heap exhaustion panic");
+    defmt::warn!("{}: {}", info, Debug2Format(&info.message()));
+    semihosting::process::exit(0);
+}

--- a/examples/global_alloc.rs
+++ b/examples/global_alloc.rs
@@ -37,5 +37,5 @@ fn main() -> ! {
 #[panic_handler]
 fn panic(info: &PanicInfo) -> ! {
     defmt::error!("{}", info);
-    semihosting::process::exit(0);
+    semihosting::process::exit(-1);
 }

--- a/examples/track_usage.rs
+++ b/examples/track_usage.rs
@@ -1,0 +1,54 @@
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use cortex_m as _;
+use cortex_m_rt::entry;
+use defmt::Debug2Format;
+use defmt_semihosting as _;
+
+use core::{mem::MaybeUninit, panic::PanicInfo};
+use embedded_alloc::TlsfHeap as Heap;
+//use embedded_alloc::LlffHeap as Heap;
+
+#[global_allocator]
+static HEAP: Heap = Heap::empty();
+
+#[entry]
+fn main() -> ! {
+    // Initialize the allocator BEFORE you use it
+    const HEAP_SIZE: usize = 4096;
+    static mut HEAP_MEM: [MaybeUninit<u8>; HEAP_SIZE] = [MaybeUninit::uninit(); HEAP_SIZE];
+    unsafe { HEAP.init(&raw mut HEAP_MEM as usize, HEAP_SIZE) }
+
+    let mut alloc_vecs = alloc::vec::Vec::new();
+    let mut free_memory = HEAP_SIZE;
+    // Keep allocating until we are getting low on memory. It doesn't have to end in a panic.
+    while free_memory > 512 {
+        defmt::info!(
+            "{} of {} heap memory allocated so far...",
+            HEAP_SIZE - free_memory,
+            HEAP_SIZE
+        );
+        let new_vec = alloc::vec![1_u8; 64];
+        alloc_vecs.push(new_vec);
+        free_memory = HEAP.free();
+    }
+
+    drop(alloc_vecs);
+
+    defmt::info!(
+        "{} of {} heap memory are allocated after drop",
+        HEAP_SIZE - HEAP.free(),
+        HEAP_SIZE
+    );
+
+    semihosting::process::exit(0);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    defmt::error!("{}: {}", info, Debug2Format(&info.message()));
+    semihosting::process::exit(-1);
+}


### PR DESCRIPTION
Includes/builds on #109 .

- Added `Heap::free` and `Heap::used` for the TLSF heap.
- Added example showcasing regular heap exhaustion and example which
  shows the memory usage API.