### PR TITLE
version: 0.6.0 -> 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## [v0.7.0] - 2026-01-03
 
 ### Added
 
@@ -142,7 +142,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Initial version of the allocator
 
-[Unreleased]: https://github.com/rust-embedded/embedded-alloc/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/rust-embedded/embedded-alloc/compare/v0.7.0...HEAD
+[v0.7.0]: https://github.com/rust-embedded/embedded-alloc/compare/v0.6.0...v0.7.0
 [v0.6.0]: https://github.com/rust-embedded/embedded-alloc/compare/v0.5.1...v0.6.0
 [v0.5.1]: https://github.com/rust-embedded/embedded-alloc/compare/v0.5.0...v0.5.1
 [v0.5.0]: https://github.com/rust-embedded/embedded-alloc/compare/v0.4.3...v0.5.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ keywords = [
 ]
 license = "MIT OR Apache-2.0"
 name = "embedded-alloc"
-version = "0.6.0"
+version = "0.7.0"
 
 [features]
 default = ["llff", "tlsf"]

--- a/README.md
+++ b/README.md
@@ -1,20 +1,14 @@
 [![crates.io](https://img.shields.io/crates/d/embedded-alloc.svg)](https://crates.io/crates/embedded-alloc)
-[![crates.io](https://img.shields.io/crates/v/embedded-alloc.svg)](https://crates.io/crates/embedded-alloc)
-![Minimum Supported Rust Version](https://img.shields.io/badge/rustc-1.68+-blue.svg) -
+[![crates.io](https://img.shields.io/crates/v/embedded-alloc.svg)](https://crates.io/crates/embedded-alloc) -
  [Documentation](https://docs.rs/embedded-alloc) - [Change log](https://github.com/rust-embedded/embedded-alloc/blob/master/CHANGELOG.md)
 
 # `embedded-alloc`
 
 > A heap allocator for embedded systems.
 
-Note that using this as your global allocator requires Rust 1.68 or later.
-(With earlier versions, you need the unstable feature `#![feature(default_alloc_error_handler)]`)
-
 This project is developed and maintained by the [libs team][team].
 
 ## Example
-
-Starting with Rust 1.68, this crate can be used as a global allocator on stable Rust:
 
 ```rust
 #![no_std]


### PR DESCRIPTION
Closes #113

Edit: I updated the README to reflect status of this release.  This crate no longer compiles with 1.68, which is fairly old at this point.