### PR TITLE
Fix builds with nightly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![doc = include_str!("../README.md")]
 #![no_std]
-#![cfg_attr(feature = "allocator_api", feature(allocator_api, alloc_layout_extra))]
+#![cfg_attr(feature = "allocator_api", feature(allocator_api))]
 #![warn(missing_docs)]
 
 #[cfg(feature = "llff")]

--- a/src/llff.rs
+++ b/src/llff.rs
@@ -111,7 +111,7 @@ mod allocator_api {
     unsafe impl Allocator for Heap {
         fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
             match layout.size() {
-                0 => Ok(NonNull::slice_from_raw_parts(layout.dangling(), 0)),
+                0 => Ok(NonNull::slice_from_raw_parts(layout.dangling_ptr(), 0)),
                 size => self.alloc(layout).map_or(Err(AllocError), |allocation| {
                     Ok(NonNull::slice_from_raw_parts(allocation, size))
                 }),

--- a/src/tlsf.rs
+++ b/src/tlsf.rs
@@ -147,7 +147,7 @@ mod allocator_api {
     unsafe impl Allocator for Heap {
         fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
             match layout.size() {
-                0 => Ok(NonNull::slice_from_raw_parts(layout.dangling(), 0)),
+                0 => Ok(NonNull::slice_from_raw_parts(layout.dangling_ptr(), 0)),
                 size => self.alloc(layout).map_or(Err(AllocError), |allocation| {
                     Ok(NonNull::slice_from_raw_parts(allocation, size))
                 }),


### PR DESCRIPTION
Fix builds with nightly

- Remove `feature(alloc_layout_extra)`, it is now stable:
  <https://github.com/rust-lang/rust/issues/55724>
- Change `Layout.dangling` to `Layout.dangling_ptr` to match name change:
  <https://github.com/rust-lang/rust/pull/148769>

--- 

Fixes #116
Fixes #117