### PR TITLE
fix(tlsf): forward realloc to tlsf

### DIFF
--- a/src/tlsf.rs
+++ b/src/tlsf.rs
@@ -104,6 +104,15 @@ impl Heap {
         })
     }
 
+    unsafe fn realloc(&self, ptr: *mut u8, new_layout: Layout) -> Option<NonNull<u8>> {
+        critical_section::with(|cs| {
+            self.heap
+                .borrow_ref_mut(cs)
+                .tlsf
+                .reallocate(NonNull::new_unchecked(ptr), new_layout)
+        })
+    }
+
     /// Get the amount of bytes used by the allocator.
     pub fn used(&self) -> usize {
         critical_section::with(|cs| {
@@ -143,6 +152,15 @@ unsafe impl GlobalAlloc for Heap {
 
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
         self.dealloc(ptr, layout)
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        // SAFETY: `layout.align()` is a power of two, and the size precondition
+        // is upheld by the caller.
+        let new_layout =
+            unsafe { core::alloc::Layout::from_size_align_unchecked(new_size, layout.align()) };
+        self.realloc(ptr, new_layout)
+            .map_or(ptr::null_mut(), |allocation| allocation.as_ptr())
     }
 }
 


### PR DESCRIPTION
Hi!

I am working in an embedded context that shipped some shims for C `realloc`. The shim simply delegates the allocation/reallocation to the global Rust allocator.
It passed a dummy layout to `alloc::realloc` and `alloc::dealloc`, assuming that the global allocator ignore them and retrieve the original layout on its own.
I am currently using the tlsf allocator ad global allocator.
So I discovered a bug where the current `embedded-alloc` implementation doesn't ignore the dummy layout in the case of reallocations because it used the default implementation of the Rust library.
This is a bug: `realloc` should be forwarded to the underlying rlsf crate.
This PR fixes this bug.